### PR TITLE
Fix broken contributor and artist pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .env
 .env.production
 .env.development
+*.local

--- a/src/modules/users/components/ArtistPage.js
+++ b/src/modules/users/components/ArtistPage.js
@@ -4,7 +4,6 @@ import { Grid, Row, Col } from "react-bootstrap/lib";
 import { Helmet } from "react-helmet";
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
-import humps from "humps";
 
 import { ArticleList } from "../../articles/components";
 import { NotFoundPage } from "../../core/components";
@@ -84,7 +83,6 @@ const styles = {
 };
 
 const ArtistPage = ({ classes, data }) => {
-  data = humps.camelizeKeys(data);
   if (data.loading) {
     return null;
   }
@@ -99,22 +97,22 @@ const ArtistPage = ({ classes, data }) => {
     ...medium.article,
     media: [
       {
-        mediaType: medium.mediaType,
+        media_type: medium.media_type,
         title: medium.title,
-        attachmentUrl: medium.attachmentUrl,
+        attachment_url: medium.attachment_url,
       },
     ],
   }));
   return (
     <Grid className={classes.ArtistPage}>
       <Helmet titleTemplate="%s | The Stuyvesant Spectator">
-        <title>{`${artist.firstName} ${artist.lastName}`}</title>
+        <title>{`${artist.first_name} ${artist.last_name}`}</title>
         <meta />
       </Helmet>
       <Row>
         <Col xs={12} sm={12} md={9} lg={9}>
           <p className={classes.name}>
-            {`${artist.firstName} ${artist.lastName}`}
+            {`${artist.first_name} ${artist.last_name}`}
           </p>
           <a href={`mailto:${artist.email}`} className={classes.email}>
             {artist.email}

--- a/src/modules/users/components/ContributorPage.js
+++ b/src/modules/users/components/ContributorPage.js
@@ -4,7 +4,6 @@ import { Grid, Row, Col } from "react-bootstrap/lib";
 import { Helmet } from "react-helmet";
 import { graphql } from "react-apollo";
 import gql from "graphql-tag";
-import humps from "humps";
 
 import { ArticleList } from "../../articles/components";
 import { NotFoundPage } from "../../core/components";
@@ -80,7 +79,6 @@ const ContributorPage = ({ classes, data }) => {
   if (data.loading) {
     return null;
   }
-  data = humps.camelizeKeys(data);
   const contributor = data.userBySlug;
   if (contributor === null) {
     return <NotFoundPage />;
@@ -88,13 +86,13 @@ const ContributorPage = ({ classes, data }) => {
   return (
     <Grid>
       <Helmet titleTemplate="%s | The Stuyvesant Spectator">
-        <title>{`${contributor.firstName} ${contributor.lastName}`}</title>
+        <title>{`${contributor.first_name} ${contributor.last_name}`}</title>
         <meta />
       </Helmet>
       <Row>
         <Col xs={12} sm={12} md={9} lg={9}>
           <p className={classes.name}>
-            {`${contributor.firstName} ${contributor.lastName}`}
+            {`${contributor.first_name} ${contributor.last_name}`}
           </p>
           <a href={`mailto:${contributor.email}`} className={classes.email}>
             {contributor.email}


### PR DESCRIPTION
The switch to snake_case graphql results resulted in broken pages, which were passing data with camelCase keys.