### PR TITLE
Ad click analytics

### DIFF
--- a/src/modules/RoutingApp.js
+++ b/src/modules/RoutingApp.js
@@ -38,6 +38,8 @@ import { RecruitmentPage } from "./recruitment/components";
 
 import { ClassifiedsRedirect } from "./core/components";
 
+import { adRedirects } from './advertisements/constants';
+
 const RoutingAppQuery = gql`
   query RoutingAppQuery {
     allSections {
@@ -111,6 +113,16 @@ class RoutingAppUnconnected extends PureComponent {
                   />
                 );
               })}
+              {adRedirects.map(ad => {
+                return (
+                  <Route
+                    path={`/ad/${ad[0]}`}
+                    key={`/ad/${ad[0]}`}
+                    render={() => {window.location.replace(ad[1]); return null;}}
+                  />
+                );
+              })
+              }
               <Route
                 exact
                 path={"/about/:description_slug"}
@@ -154,8 +166,8 @@ class RoutingAppUnconnected extends PureComponent {
                   session ? (
                     <Redirect to="/myaccount/profile" />
                   ) : (
-                    <SignInPage />
-                  )}
+                      <SignInPage />
+                    )}
               />
               <Route
                 exact
@@ -165,8 +177,8 @@ class RoutingAppUnconnected extends PureComponent {
                   session ? (
                     <Redirect to="/myaccount/profile" />
                   ) : (
-                    <SignUpPage />
-                  )}
+                      <SignUpPage />
+                    )}
               />
               <Route
                 exact

--- a/src/modules/advertisements/constants.js
+++ b/src/modules/advertisements/constants.js
@@ -4,3 +4,5 @@ export default {
 
 //PUBLIC_URL replaced by path to public folder at build time
 export const pathToAds = process.env.PUBLIC_URL + "/img/ads/";
+
+export const adRedirects = [['compass-to-college', 'http://www.compasstocollege.org']];

--- a/src/modules/advertisements/reducer.js
+++ b/src/modules/advertisements/reducer.js
@@ -2,7 +2,7 @@ const initialState = [
   {
     company: "Compas To College",
     filename: "compass-to-college.jpg",
-    url: "http://www.compasstocollege.org",
+    url: '/ad/compass-to-college',
   },
 ];
 


### PR DESCRIPTION
Business has requested the ability to get ad click counts to obtain data for current and potential future clients. This pull request modifies ads so that on click, they first direct the user to a spec `/ad` link, which Google Analytics will log. That route then redirects the user to the appropriate ad purchaser's page. 